### PR TITLE
Flush cache of Contracts on changing ContractAddresses and WalletProvider

### DIFF
--- a/src/contracts/state.ts
+++ b/src/contracts/state.ts
@@ -20,10 +20,16 @@ const state: State = {
 
 export const setContractAddresses = (contractAddresses: ContractsAddresses) => {
   state.contractAddresses = contractAddresses;
+
+  state.writeContracts = {} as any;
+  state.readContracts = {} as any;
 }
 
 export const setWallerProvider = (walletProvider: Web3Provider) => {
   state.walletProvider = walletProvider
+
+  state.writeContracts = {} as any;
+  state.readContracts = {} as any;
 }
 
 export const setSelectedChainId = (selectedChainId: number) => {


### PR DESCRIPTION
We are using the cached Contracts and once we have changed the Contract Addresses or Wallet Provider we are still using these Contracts created with old values