### PR TITLE
Fix: proper determining latestBlock in case no events fetched

### DIFF
--- a/src/api/fetchConditions.ts
+++ b/src/api/fetchConditions.ts
@@ -96,7 +96,7 @@ const fetchConditions = async (props?: FetchConditionsProps): Promise<Conditions
 
   return {
     conditions: conditions.filter(Boolean),
-    latestBlock: events[events.length - 1].blockNumber,
+    latestBlock: events.length > 0 ? events[events.length - 1].blockNumber : (props?.from || 0),
   }
 }
 


### PR DESCRIPTION
Fix: proper determining latestBlock in case no events fetched