### PR TITLE
Update usePrepareBet.ts

### DIFF
--- a/src/hooks/usePrepareBet.ts
+++ b/src/hooks/usePrepareBet.ts
@@ -106,7 +106,7 @@ export const usePrepareBet = (props: Props) => {
     if (
       !betAmount
       || typeof allowanceTx?.data === 'undefined'
-      || typeof relayerFeeAmount === 'undefined'
+      || (isLiveBet && typeof relayerFeeAmount === 'undefined')
     ) {
       return false
     }


### PR DESCRIPTION
relayerFeeAmount is always undefined for prematch bets, so it was always returning `false` in `isApproveRequired` even if the user had not approved the prematch betting contract for the token.